### PR TITLE
Add local-aur gpg

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,13 +1,13 @@
 # Maintainer: rpkak <rpkak@users.noreply.github.com>
 pkgname='local-aur'
-pkgver=0.4.0.r9.gfcd7e77
+pkgver=0.4.1
 pkgrel=1
 epoch=
 pkgdesc="Download the AUR packages you trust and use pacman to install them."
 arch=('any')
 url="https://github.com/rpkak/local-aur"
 license=('Apache')
-depends=('pacman' 'git' 'python3' 'tar' 'zstd' $(pacman -Sgq base-devel))
+depends=('pacman' 'git' 'python3' 'tar' 'zstd' 'gnupg' $(pacman -Sgq base-devel))
 makedepends=()
 checkdepends=()
 optdepends=()

--- a/README.md
+++ b/README.md
@@ -80,6 +80,29 @@ To uninstall it from pacman, just execute:
 pacman -Rs [pkgnames]
 ```
 
+### Managing GPG-keys
+
+To verify some packages gpg is used. `local-aur gpg` calls gpg for local-aur.
+
+For example if you want to install spotify, you get this error:
+
+```
+$ sudo local-aur build spotify
+[...]
+==> Verifying source file signatures with gpg...
+    spotify-1.1.84.716-2-Release ... FAILED (unknown public key 5E3C45D7B312C643)
+==> ERROR: One or more PGP signatures could not be verified!
+local-aur: E  Executing "makepkg" returned 1
+local-aur: W  Failed to build package.
+local-aur: W  No packages to add to database.
+```
+
+This can be fixed by:
+
+```
+local-aur gpg --recv-key 5E3C45D7B312C643
+```
+
 ## Installation
 
 With executing

--- a/local-aur
+++ b/local-aur
@@ -237,13 +237,17 @@ if __name__ == '__main__':
     remove_parser.add_argument(
         'packages', nargs='+', help='Packages to remove from the local-aur repo.')
 
-    remove_parser = subparsers.add_parser('list', help='Lists packages')
-    remove_parser.set_defaults(command='list')
-    g = remove_parser.add_mutually_exclusive_group()
+    list_parser = subparsers.add_parser('list', help='Lists packages')
+    list_parser.set_defaults(command='list')
+    g = list_parser.add_mutually_exclusive_group()
     g.add_argument('-p', '--pacman', action='store_true',
                    help='Show aur and pacman packages.')
     g.add_argument('-P', '--pacman-only', action='store_true',
                    help='Show pacman packages only.')
+
+    gpg_parser = subparsers.add_parser('gpg', help='Calls gpg to change the keys used for local-aur.', add_help=False, prefix_chars='\0')
+    gpg_parser.set_defaults(command='gpg')
+    gpg_parser.add_argument('options', nargs='*', help='Options for the gpg command.')
 
     args = parser.parse_args()
 
@@ -263,6 +267,9 @@ if __name__ == '__main__':
         elif args.command == 'list':
             list_packages(not args.pacman_only,
                           args.pacman or args.pacman_only)
+        elif args.command == 'gpg':
+            check_permissions()
+            run(['/usr/bin/gpg', *args.options])
     except KeyboardInterrupt:
         logging.error('Canceling')
         exit(130)

--- a/tests/key.sh
+++ b/tests/key.sh
@@ -6,6 +6,6 @@ pacman -Sy --asdeps --noconfirm alsa-lib gtk3 libxss desktop-file-utils nss at-s
 
 ! local-aur build spotify
 
-local-aur key --recv-key 5E3C45D7B312C643
+local-aur gpg --recv-key 5E3C45D7B312C643
 
 local-aur build spotify

--- a/tests/key.sh
+++ b/tests/key.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+pacman -Sy --asdeps --noconfirm alsa-lib gtk3 libxss desktop-file-utils nss at-spi2-atk libcurl-gnutls libsm
+
+! local-aur build spotify
+
+local-aur key --recv-key 5E3C45D7B312C643
+
+local-aur build spotify


### PR DESCRIPTION
replaces #23

Allow users to configure gpg and add/remove gpg keys.

`local-aur gpg` just calls `gpg` for local-aur.

More info [here](https://github.com/rpkak/local-aur/pull/23#issuecomment-1200302818).